### PR TITLE
Fix naturalearth download link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ target/
 latlon_utils/data/*
 !latlon_utils/data/README.rst
 
+.mypy_cache

--- a/latlon_utils/download.py
+++ b/latlon_utils/download.py
@@ -162,8 +162,8 @@ def download_natural_earth_countries(outdir=None):
         os.makedirs(outdir)
     download_target = osp.join(outdir, 'ne_10m_admin_0_countries.zip')
 
-    url = ('https://www.naturalearthdata.com/http//www.naturalearthdata.com/'
-           'download/10m/cultural/ne_10m_admin_0_countries.zip')
+    url = ('https://naciscdn.org/naturalearth/'
+           '10m/cultural/ne_10m_admin_0_countries.zip')
 
     if not SILENT:
         print('Downloading %s to %s' % (url, download_target))


### PR DESCRIPTION
as mentioned in #1, the natural earth download link does not work from the command line, so we are using `https://naciscdn.org/naturalearth` now (as cartopy does)