### PR TITLE
Fix broken download url for climate data

### DIFF
--- a/latlon_utils/__init__.py
+++ b/latlon_utils/__init__.py
@@ -314,9 +314,9 @@ def get_climate(lat, lon, variables=['tavg', 'prec'], res=None,
 
     def find_closest(arr, vals):
         idx = np.searchsorted(arr, vals)
+        idx[idx == arr.size] = arr.size - 1
         diff = arr[idx] - vals
         diffprev = vals - arr[idx - 1]
-        idx[idx == arr.size] = arr.size - 1
         idx[(idx > 0) & (idx < arr.size) & (diff > diffprev)] -= 1
         return idx
 

--- a/latlon_utils/download.py
+++ b/latlon_utils/download.py
@@ -13,7 +13,7 @@ from latlon_utils import (
     get_data_dir, worldclim_variables, worldclim_resolutions, __version__)
 
 
-wc_base_url = 'http://biogeo.ucdavis.edu/data/worldclim/v2.1/base/'
+wc_base_url = 'https://geodata.ucdavis.edu/climate/worldclim/2_1/base/'
 
 SILENT = False
 


### PR DESCRIPTION
** Issue **
Fixed a broken link dependency used to download climate data within the python package caused a connection error when calling the 'get_climate' function.  
Test script: 
from latlon_utils import get_country,get_climate
get_climate(50, 10)

** Current output (after the change): **

>>> from latlon_utils import get_country,get_climate
>>> get_climate(50, 10)
Downloading https://geodata.ucdavis.edu/climate/worldclim/2_1/base/wc2.1_10m_tavg.zip
Extracting /tmp/worldclim_mwixabdh/wc2.1_10m_tavg.zip
Saving as netcdf file to ~/.local/share/latlon_utils/tavg_10m.nc
~/.local/lib/python3.8/site-packages/netCDF4/utils.py:74: RuntimeWarning: overflow encountered in multiply
  datout = np.around(scale*data)/scale
Downloading https://geodata.ucdavis.edu/climate/worldclim/2_1/base/wc2.1_10m_prec.zip
Extracting /tmp/worldclim_nai4la2k/wc2.1_10m_prec.zip
Saving as netcdf file to ~/.local/share/latlon_utils/prec_10m.nc
tavg  jan     0.053223
      feb     0.958252
      mar     4.760742
      apr     8.333008
      mai    13.220520
      jun    16.089722
      jul    17.987976
      aug    17.847229
      sep    13.790222
      oct     8.807007
      nov     4.054260
      dec     1.496521
      djf     0.835999
      mam     8.771423
      jja    17.308309
      son     8.883830
      ann     8.949890
prec  jan    48.000000
      feb    42.000000
      mar    44.000000
      apr    44.000000
      mai    56.000000
      jun    68.000000
      jul    65.000000
      aug    52.000000
      sep    47.000000
      oct    52.000000
      nov    52.000000
      dec    59.000000
      djf    49.666667
      mam    48.000000
      jja    61.666667
      son    50.333333
      ann    52.416667
Name: (50, 10), dtype: float64